### PR TITLE
Fixes for Model download, Screenshots cancelling and Language sort

### DIFF
--- a/frog/config.py
+++ b/frog/config.py
@@ -33,6 +33,8 @@ RESOURCE_PREFIX = "/com/github/tenderowl/frog"
 if not os.path.exists(os.path.join(os.environ['XDG_DATA_HOME'], 'tessdata')):
     os.mkdir(os.path.join(os.environ['XDG_DATA_HOME'], 'tessdata'))
 
-tessdata_url = "https://github.com/tesseract-ocr/tessdata_best/raw/main/"
+
+tessdata_url = "https://github.com/tesseract-ocr/tessdata/raw/main/"
+tessdata_best_url = "https://github.com/tesseract-ocr/tessdata_best/raw/main/"
 tessdata_dir = os.path.join(os.environ['XDG_DATA_HOME'], 'tessdata')
 tessdata_dir_config = f'--tessdata-dir {tessdata_dir}'

--- a/frog/language_dialog.py
+++ b/frog/language_dialog.py
@@ -66,8 +66,8 @@ class LanguagePacksDialog(Granite.Dialog):
 
         See https://lazka.github.io/pgi-docs/index.html#Gtk-3.0/callbacks.html#Gtk.ListBoxSortFunc for details.
         """
-        lang_row1: LanguageRow = row1.get_child().lang_code
-        lang_row2: LanguageRow = row2.get_child().lang_code
+        lang_row1: LanguageRow = row1.get_child()
+        lang_row2: LanguageRow = row2.get_child()
         lang1 = language_manager.get_language(lang_row1.lang_code)
         lang2 = language_manager.get_language(lang_row2.lang_code)
 

--- a/frog/language_manager.py
+++ b/frog/language_manager.py
@@ -8,7 +8,7 @@ from urllib import request
 
 from gi.repository import GObject
 
-from frog.config import tessdata_dir, tessdata_url
+from frog.config import tessdata_dir, tessdata_url, tessdata_best_url
 from frog.gobject_worker import GObjectWorker
 
 
@@ -200,10 +200,17 @@ class LanguageManager(GObject.GObject):
         tessfile_path = os.path.join(tessdata_dir, tessfile)
         print(f'Data will be extracted to: {tessfile_path}')
         try:
-            request.urlretrieve(tessdata_url + tessfile, tessfile_path)
+            request.urlretrieve(tessdata_best_url + tessfile, tessfile_path)
             return code
         except Exception as e:
             print(e)
+            try:
+                print(f"{code} not found in tessdata_best, checking tessdata")
+                request.urlretrieve(tessdata_url + tessfile, tessfile_path)
+                return code
+            except Exception as e2:
+                print(e2)
+                print(f"{code} was not found at tessdata")
 
     def download_done(self, code):
         self.emit('downloaded', code)

--- a/frog/window.py
+++ b/frog/window.py
@@ -218,11 +218,14 @@ class FrogWindow(Handy.ApplicationWindow):
     def on_shot_error(self, error) -> None:
         print(f"ERROR: {error}")
         if error:
-            self.on_screenshot_error(error)
+            self.on_screenshot_error(self, error)
         self.present()
 
     def on_screenshot_error(self, sender, error) -> None:
-        self.infobar_label.set_text(error)
+        if not isinstance(error, str):
+            self.infobar_label.set_text(str(error).split(':')[-1])
+        else:
+            self.infobar_label.set_text(error)
         self.infobar.set_revealed(True)
         self.infobar.set_visible(True)
         self.infobar.set_message_type(Gtk.MessageType.ERROR)


### PR DESCRIPTION
Related Issue : 

-  Fixes  #27   

Proposed Changes: 

- Using the link to tesseract-ocr/tessdata as a backup source, if the required model is not found under tessdata-best

Result: 

- The math module can now be installed, And any modules which were removed from tessdata-best.


Additional changes:

- Cancelling screenshot using ESC key  would result in the app stopping abruptly
 
	![frog_error_scrnCancel](https://user-images.githubusercontent.com/56635847/152790586-2e9e4cd8-d842-49d7-8f91-8955c222dd5c.png)

	Changes: 

	- Fixed minor errors in window.py 

	Result:

	- The screenshot can be cancelled without breaking the app

- Opening Languages dialog window would create a lot of errors in when run through the terminal. It prevents sorting of languages by name in the UI.

	![frog_error_langSort](https://user-images.githubusercontent.com/56635847/152790211-5c9977b6-8d0b-4a2e-8b00-217c636c56e3.png)

	Changes: 

	- Fixed minor issue in language_dialog.py

	Result: 

	- Opening Language window will not produce errors.
	- The list of languages are now sorted in order