### PR TITLE
Add missing `Ctrl+Q` quit shortcut

### DIFF
--- a/data/ui/shortcuts.ui
+++ b/data/ui/shortcuts.ui
@@ -34,6 +34,12 @@
                 <property name="title" translatable="yes" context="shortcut window">Display preferences</property>
               </object>
             </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="accelerator">&lt;ctrl&gt;q</property>
+                <property name="title" translatable="yes" context="shortcut window">Quit</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/frog/main.py
+++ b/frog/main.py
@@ -121,6 +121,11 @@ class Application(Adw.Application):
         action.connect("activate", self.on_about)
         self.add_action(action)
 
+        action = Gio.SimpleAction.new(name="quit", parameter_type=None)
+        action.connect("activate", self.on_quit)
+        self.add_action(action)
+        self.set_accels_for_action("app.quit", ("<Control>q",))
+
     def do_activate(self):
         win = self.props.active_window
         if not win:
@@ -144,6 +149,9 @@ class Application(Adw.Application):
     def on_about(self, _action, _param):
         about_dialog = AboutDialog(transient_for=self.props.active_window, modal=True, version=self.version)
         about_dialog.present()
+
+    def on_quit(self, _action, _param):
+        self.quit()
 
     def on_shortcuts(self, _action, _param):
         builder = Gtk.Builder()


### PR DESCRIPTION
`Ctrl+Q` is a standard shortcut to quit an application in the [GNOME Human Interface Guidelines](https://developer.gnome.org/hig/reference/keyboard.html)