### PR TITLE
Include "Japanese (vertical)" to list of languages

### DIFF
--- a/frog/language_manager.py
+++ b/frog/language_manager.py
@@ -86,6 +86,7 @@ class LanguageManager(GObject.GObject):
         self._languages["ita_old"] = _("Italian - Old")
         self._languages["jav"] = _("Javanese")
         self._languages["jpn"] = _("Japanese")
+        self._languages["jpn_vert"] = _("Japanese (vertical)")
         self._languages["kan"] = _("Kannada")
         self._languages["kat"] = _("Georgian")
         self._languages["kat_old"] = _("Georgian - Old")


### PR DESCRIPTION
Tesseract supports OCR'ing japanese text in vertical mode, and has a trained model in their tessdata(_best) repo.