### PR TITLE
Fix for the hungarian language code

### DIFF
--- a/frog/language_manager.py
+++ b/frog/language_manager.py
@@ -77,7 +77,7 @@ class LanguageManager(GObject.GObject):
         self._languages["heb"] = _("Hebrew")
         self._languages["hin"] = _("Hindi")
         self._languages["hrv"] = _("Croatian")
-        self._languages["huselfn"] = _("Hungarian")
+        self._languages["hun"] = _("Hungarian")
         self._languages["hye"] = _("Armenian")
         self._languages["iku"] = _("Inuktitut")
         self._languages["ind"] = _("Indonesian")


### PR DESCRIPTION
In this PR I changed the language code for the hungarian lang from 'huselfn' to 'hun'.
I guess that somehow 'self' got in it once and no one noticed it :smile:
I haven't built the app with the change, but tested that the url: https://github.com/tesseract-ocr/tessdata_best/raw/main/hun.traineddata works