### PR TITLE
Add mobile metadata to .desktop file

### DIFF
--- a/data/com.github.tenderowl.frog.desktop.in
+++ b/data/com.github.tenderowl.frog.desktop.in
@@ -10,6 +10,8 @@ Categories=GTK;Utility;Office;
 StartupNotify=true
 Keywords=OCR;Text;Extraction;
 Actions=extractToClipboard;
+# Translators: Do NOT translate or transliterate this text (these are enum types)!
+X-Purism-FormFactor=Workstation;Mobile;
 
 [Desktop Action extractToClipboard]
 Name=Extract Text to the Clipboard


### PR DESCRIPTION
This will enable the app to appear on the home screen without needing to toggle the All Apps view as this app is adaptive.

Code taken from Flatseal: https://github.com/tchx84/Flatseal/blob/master/data/com.github.tchx84.Flatseal.desktop.in#L12C1-L13