### PR TITLE
Alt access keys

### DIFF
--- a/data/ui/extracted_page.blp
+++ b/data/ui/extracted_page.blp
@@ -25,7 +25,8 @@ template $ExtractedPage : Box {
       menu-model: grab_menu;
 
       child: Adw.ButtonContent {
-        label: "Grab";
+        label: "_Grab";
+        use-underline: true;
         icon-name: "camera-photo-symbolic";
       };
     }

--- a/data/ui/preferences_general.blp
+++ b/data/ui/preferences_general.blp
@@ -2,14 +2,16 @@ using Gtk 4.0;
 using Adw 1;
 
 template $PreferencesGeneralPage : Adw.PreferencesPage {
-  title: _("General");
+  title: _("_General");
+  use-underline: true;
   icon-name: "emblem-system-symbolic";
 
   Adw.PreferencesGroup {
     title: _("Text Extracting");
 
     Adw.ComboRow extra_language_combo {
-      title: _("Second language");
+      title: _("_Second language");
+      use-underline: true;
       subtitle: _("Additional language used in text recognition");
     }
   }
@@ -18,7 +20,8 @@ template $PreferencesGeneralPage : Adw.PreferencesPage {
     title: _("Behavior");
 
     Adw.ActionRow {
-      title: _("Copy to clipboard");
+      title: _("_Copy to clipboard");
+      use-underline: true;
       subtitle: _("Automatically copy the extracted text to clipboard");
       activatable-widget: autocopy_switch;
 
@@ -28,7 +31,8 @@ template $PreferencesGeneralPage : Adw.PreferencesPage {
     }
 
     Adw.ActionRow {
-      title: _("Open QR-code links");
+      title: _("_Open QR-code links");
+      use-underline: true;
       subtitle: _("Automatically open links from QR-codes");
       activatable-widget: autolinks_switch;
 

--- a/data/ui/preferences_languages.blp
+++ b/data/ui/preferences_languages.blp
@@ -2,7 +2,8 @@ using Gtk 4.0;
 using Adw 1;
 
 template $PreferencesLanguagesPage : Adw.PreferencesPage {
-  title: _("Languages");
+  title: _("_Languages");
+  use-underline: true;
   icon-name: "preferences-desktop-locale-symbolic";
 
   Box {

--- a/data/ui/welcome_page.blp
+++ b/data/ui/welcome_page.blp
@@ -116,6 +116,6 @@ menu primary_menu {
 }
 
 menu grab_menu {
-    item (_("_Open image"), "app.open_image", "folder-open-symbolic")
-    item (_("_Paste from clipboard"), "app.paste_from_clipboard", "folder-open-symbolic")
+    item (_("Open image"), "app.open_image", "folder-open-symbolic")
+    item (_("Paste from clipboard"), "app.paste_from_clipboard", "folder-open-symbolic")
 }

--- a/data/ui/welcome_page.blp
+++ b/data/ui/welcome_page.blp
@@ -64,7 +64,8 @@ template $WelcomePage : Box {
             }
 
             Label {
-              label: _("Take a Screenshot");
+              label: _("_Take a Screenshot");
+              use-underline: true;
             }
           };
         }
@@ -83,7 +84,8 @@ template $WelcomePage : Box {
             }
 
             Label {
-              label: _("Open Image");
+              label: _("_Open Image");
+              use-underline: true;
             }
           };
         }
@@ -114,6 +116,6 @@ menu primary_menu {
 }
 
 menu grab_menu {
-    item (_("Open image"), "app.open_image", "folder-open-symbolic")
-    item (_("Paste from clipboard"), "app.paste_from_clipboard", "folder-open-symbolic")
+    item (_("_Open image"), "app.open_image", "folder-open-symbolic")
+    item (_("_Paste from clipboard"), "app.paste_from_clipboard", "folder-open-symbolic")
 }


### PR DESCRIPTION
Added several access keys that allow easier navigation from keyboard

Press and hold Alt to see underlined letters of buttons' labels (they are generally the very first) and press Alt+<Letter> to simulate a mouse click on that button. This is standard GTK feature and does not require any additional packages — only one attribute (use-underline) and an underline right before the letter to be pressed

This contribution was done as part of the [First Contribution Hackathon](https://pesader.dev/posts/1st-contribution-hackathon/) on GUADEC 2023