### PR TITLE
data: Mark release descriptions as untranslatable

### DIFF
--- a/data/com.github.tenderowl.frog.appdata.xml.in
+++ b/data/com.github.tenderowl.frog.appdata.xml.in
@@ -20,7 +20,7 @@
 
     <releases>
         <release version="1.4.2" type="stable" date="2023-08-31">
-            <description>
+            <description translatable="no">
                 <p>What's new:</p>
                 <ul>
                     <li>Translations updated.</li>
@@ -28,7 +28,7 @@
             </description>
         </release>
         <release version="1.4.0" type="stable" date="2023-08-22">
-            <description>
+            <description translatable="no">
                 <p>In this update, we've made a number of improvements to our app.</p>
                 <ul>
 		    <li>Share extracted text: This means you can now share your findings with the wider community.</li>
@@ -46,7 +46,7 @@
             </description>
         </release>
         <release version="1.3.0" type="stable" date="2023-03-21">
-            <description>
+            <description translatable="no">
                 <p>In this update, we've made a number of improvements to our app.</p>
                 <ul>
                     <li>We have redesigned the settings dialog to make it more user-friendly and understandable.</li>
@@ -60,7 +60,7 @@
             </description>
         </release>
         <release version="1.2.0" type="stable" date="2022-08-31">
-            <description>
+            <description translatable="no">
                 <p>What's new:</p>
                 <ul>
                     <li>Open image button now available.</li>
@@ -69,7 +69,7 @@
             </description>
         </release>
         <release version="1.1.3" type="stable" date="2022-06-15">
-            <description>
+            <description translatable="no">
                 <p>What's new:</p>
                 <ul>
                     <li>Translations updated.</li>
@@ -77,7 +77,7 @@
             </description>
         </release>
         <release version="1.1.1" type="stable" date="2022-06-07">
-            <description>
+            <description translatable="no">
                 <p>What's new:</p>
                 <ul>
                     <li>When no text is found, Frog returns to the main window.</li>
@@ -86,7 +86,7 @@
             </description>
         </release>
         <release version="1.1.0" type="stable" date="2022-06-06">
-            <description>
+            <description translatable="no">
                 <p>What's new:</p>
                 <ul>
                     <li>Updated UI</li>
@@ -95,7 +95,7 @@
             </description>
         </release>
         <release version="1.0.0" type="stable" date="2022-04-18">
-            <description>
+            <description translatable="no">
                 <p>What's new:</p>
                 <ul>
                     <li>Updated UI</li>
@@ -106,18 +106,18 @@
             </description>
         </release>
         <release version="0.3.0" type="stable" date="2022-03-21">
-            <description>
+            <description translatable="no">
                 <p>Frog now is available on the Flathub and use modern Portal implementation.
                 We also updated the UI accordingly to the GNOME HIG and fixed some bugs we've found :)</p>
             </description>
         </release>
         <release version="0.2.1" date="2021-12-11">
-            <description>
+            <description translatable="no">
                 <p>Now you're free to run Frog with `-e` option to extract text and instantly copy it to the clipboard.</p>
             </description>
         </release>
         <release version="0.2.0" timestamp="1639071856">
-            <description>
+            <description translatable="no">
                 <p>What's new:</p>
                 <ul>
                     <li>English model included with Frog itself</li>
@@ -128,12 +128,12 @@
             </description>
         </release>
         <release version="0.1.7" timestamp="1632324626" date="2021-09-22">
-            <description>
+            <description translatable="no">
                 <p>Fix language packs download.</p>
             </description>
         </release>
         <release version="0.1.6" timestamp="1631035973" date="2021-09-07">
-            <description>
+            <description translatable="no">
                 <p>Dark mode+</p>
                 <ul>
                     <li>Dark mode support.</li>
@@ -142,7 +142,7 @@
             </description>
         </release>
         <release version="0.1.5" timestamp="1630132049" date="2021-08-28">
-            <description>
+            <description translatable="no">
                 <p>Quickly extract any text from anywhere you need it: webpages, videos, photos, etc.</p>
             </description>
         </release>

--- a/po/frog.pot
+++ b/po/frog.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frog 1.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-23 02:01+0300\n"
+"POT-Creation-Date: 2023-10-03 19:37+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,64 +17,182 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../frog/services/clipboard_service.py:54
-msgid "No image in clipboard"
+#: ../data/com.github.tenderowl.frog.appdata.xml.in:6
+#: ../data/com.github.tenderowl.frog.desktop.in:3
+msgid "Frog"
 msgstr ""
 
-#: ../frog/services/screenshot_service.py:93
-msgid "Can't take a screenshot."
+#: ../data/com.github.tenderowl.frog.appdata.xml.in:7
+msgid "Extract text from images"
 msgstr ""
 
-#: ../frog/widgets/preferences_languages_page.py:100
-msgid "View all available languages"
+#: ../data/com.github.tenderowl.frog.appdata.xml.in:9
+msgid ""
+"Extract text from images, websites, videos, and QR codes by taking a picture "
+"of the source."
 msgstr ""
 
-#: ../frog/widgets/share_row.py:48
-msgid "Share via {provider_name.capitalize()}"
+#: ../data/com.github.tenderowl.frog.appdata.xml.in:151
+msgid "Tender Owl"
 msgstr ""
 
-#: ../frog/main.py:63 ../frog/main.py:83
-msgid "Extract directly into the clipboard"
+#: ../data/com.github.tenderowl.frog.desktop.in:4
+msgid "Text extraction tool"
 msgstr ""
 
-#: ../frog/main.py:188
-msgid "No text found. Try to grab another region."
+#: ../data/com.github.tenderowl.frog.desktop.in:5
+msgid "Extract text from any image, video or web page"
 msgstr ""
 
-#: ../frog/main.py:198
-msgid "Text extracted. You can paste it with Ctrl+V"
+#: ../data/com.github.tenderowl.frog.desktop.in:12
+msgid "OCR;Text;Extraction;"
 msgstr ""
 
-#: ../frog/window.py:151
-msgid "Text copied to clipboard"
+#: ../data/com.github.tenderowl.frog.desktop.in:18
+msgid "Extract Text to the Clipboard"
 msgstr ""
 
-#: ../frog/window.py:162
-msgid "QR-code URL opened"
+#: ../data/ui/extracted_page.blp:18 ../data/ui/welcome_page.blp:29
+msgid "Take a screenshot"
 msgstr ""
 
-#: ../frog/window.py:166
-msgid "QR-code contains URL."
+#: ../data/ui/extracted_page.blp:26
+msgctxt "Extracted screen"
+msgid "Copy extracted text to clipboard"
 msgstr ""
 
-#: ../frog/window.py:167
-msgid "Open"
+#: ../data/ui/extracted_page.blp:33
+msgctxt "Extracted screen"
+msgid "Listen to text"
 msgstr ""
 
-#: ../frog/window.py:194
-msgid "Supported image files"
+#: ../data/ui/extracted_page.blp:40
+msgctxt "Extracted screen"
+msgid "Cancel listening to text"
 msgstr ""
 
-#: ../frog/window.py:200
-msgid "Open image to extract text"
+#: ../data/ui/extracted_page.blp:53
+msgctxt "Extracted screen"
+msgid "Open menu"
 msgstr ""
 
-#: ../frog/window.py:260
-msgid "Only images can be processed that way."
+#: ../data/ui/extracted_page.blp:60
+msgctxt "Extracted screen"
+msgid "Share To"
 msgstr ""
 
-#: ../frog/window.py:293
-msgid "Text copied"
+#: ../data/ui/extracted_page.blp:97 ../data/ui/welcome_page.blp:104
+msgid "Preferences"
+msgstr ""
+
+#: ../data/ui/extracted_page.blp:104 ../data/ui/welcome_page.blp:111
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: ../data/ui/extracted_page.blp:109 ../data/ui/welcome_page.blp:116
+msgid "About Frog"
+msgstr ""
+
+#: ../data/ui/extracted_page.blp:117 ../data/ui/welcome_page.blp:123
+msgid "Open image"
+msgstr ""
+
+#: ../data/ui/extracted_page.blp:118 ../data/ui/welcome_page.blp:124
+msgid "Paste from clipboard"
+msgstr ""
+
+#: ../data/ui/language_dialog.blp:14
+msgid "Available Languages"
+msgstr ""
+
+#: ../data/ui/language_popover.blp:18
+msgid "Search language"
+msgstr ""
+
+#: ../data/ui/preferences_general.blp:5
+msgid "_General"
+msgstr ""
+
+#: ../data/ui/preferences_general.blp:10
+msgid "Text Extracting"
+msgstr ""
+
+#: ../data/ui/preferences_general.blp:13
+msgid "_Second language"
+msgstr ""
+
+#: ../data/ui/preferences_general.blp:15
+msgid "Additional language used in text recognition"
+msgstr ""
+
+#: ../data/ui/preferences_general.blp:20
+msgid "Behavior"
+msgstr ""
+
+#: ../data/ui/preferences_general.blp:23
+msgid "_Copy to clipboard"
+msgstr ""
+
+#: ../data/ui/preferences_general.blp:25
+msgid "Automatically copy the extracted text to clipboard"
+msgstr ""
+
+#: ../data/ui/preferences_general.blp:34
+msgid "_Open QR-code links"
+msgstr ""
+
+#: ../data/ui/preferences_general.blp:36
+msgid "Automatically open links from QR-codes"
+msgstr ""
+
+#: ../data/ui/preferences_languages.blp:6
+msgid "_Languages"
+msgstr ""
+
+#: ../data/ui/preferences_languages.blp:32
+msgid "Installed languages"
+msgstr ""
+
+#: ../data/ui/share_row.blp:14
+msgid "Share via Pocket"
+msgstr ""
+
+#: ../data/ui/share_row.blp:22
+msgid "Pocket"
+msgstr ""
+
+#: ../data/ui/welcome_page.blp:12 ../data/ui/welcome_page.blp:49
+msgid "Extract text from anywhere"
+msgstr ""
+
+#: ../data/ui/welcome_page.blp:21
+msgid "Language"
+msgstr ""
+
+#: ../data/ui/welcome_page.blp:22
+msgid "Select language to extract"
+msgstr ""
+
+#: ../data/ui/welcome_page.blp:43
+msgid "Open menu"
+msgstr ""
+
+#: ../data/ui/welcome_page.blp:58
+msgctxt "Welcome screen"
+msgid "Take a Screenshot"
+msgstr ""
+
+#: ../data/ui/welcome_page.blp:70
+msgid "_Take a Screenshot"
+msgstr ""
+
+#: ../data/ui/welcome_page.blp:78
+msgctxt "Welcome screen"
+msgid "Open Image"
+msgstr ""
+
+#: ../data/ui/welcome_page.blp:90
+msgid "_Open Image"
 msgstr ""
 
 #: ../frog/language_manager.py:54 ../frog/language_manager.py:90
@@ -565,312 +683,62 @@ msgstr ""
 msgid "Yoruba"
 msgstr ""
 
-#: ../data/ui/language_popover.blp:18
-msgid "Search language"
+#: ../frog/main.py:63 ../frog/main.py:83
+msgid "Extract directly into the clipboard"
 msgstr ""
 
-#: ../data/ui/extracted_page.blp:37
-msgid "Open Image to extract text"
+#: ../frog/main.py:188
+msgid "No text found. Try to grab another region."
 msgstr ""
 
-#: ../data/ui/extracted_page.blp:136 ../data/ui/welcome_page.blp:100
-msgid "Preferences"
+#: ../frog/main.py:198
+msgid "Text extracted. You can paste it with Ctrl+V"
 msgstr ""
 
-#: ../data/ui/extracted_page.blp:143 ../data/ui/welcome_page.blp:107
-msgid "Keyboard Shortcuts"
+#: ../frog/services/clipboard_service.py:54
+msgid "No image in clipboard"
 msgstr ""
 
-#: ../data/ui/extracted_page.blp:148 ../data/ui/welcome_page.blp:112
-msgid "About Frog"
+#: ../frog/services/screenshot_service.py:93
+msgid "Can't take a screenshot."
 msgstr ""
 
-#: ../data/ui/extracted_page.blp:156 ../data/ui/welcome_page.blp:119
-msgid "Open image"
+#: ../frog/widgets/preferences_languages_page.py:100
+msgid "View all available languages"
 msgstr ""
 
-#: ../data/ui/extracted_page.blp:157 ../data/ui/welcome_page.blp:120
-msgid "Paste from clipboard"
+#: ../frog/widgets/share_row.py:48
+msgid "Share via {provider_name.capitalize()}"
 msgstr ""
 
-#: ../data/ui/language_dialog.blp:14
-msgid "Available Languages"
+#: ../frog/window.py:151
+msgid "Text copied to clipboard"
 msgstr ""
 
-#: ../data/ui/preferences_general.blp:5
-msgid "_General"
+#: ../frog/window.py:162
+msgid "QR-code URL opened"
 msgstr ""
 
-#: ../data/ui/preferences_general.blp:10
-msgid "Text Extracting"
+#: ../frog/window.py:166
+msgid "QR-code contains URL."
 msgstr ""
 
-#: ../data/ui/preferences_general.blp:13
-msgid "_Second language"
+#: ../frog/window.py:167
+msgid "Open"
 msgstr ""
 
-#: ../data/ui/preferences_general.blp:15
-msgid "Additional language used in text recognition"
+#: ../frog/window.py:194
+msgid "Supported image files"
 msgstr ""
 
-#: ../data/ui/preferences_general.blp:20
-msgid "Behavior"
+#: ../frog/window.py:200
+msgid "Open image to extract text"
 msgstr ""
 
-#: ../data/ui/preferences_general.blp:23
-msgid "_Copy to clipboard"
+#: ../frog/window.py:260
+msgid "Only images can be processed that way."
 msgstr ""
 
-#: ../data/ui/preferences_general.blp:25
-msgid "Automatically copy the extracted text to clipboard"
-msgstr ""
-
-#: ../data/ui/preferences_general.blp:34
-msgid "_Open QR-code links"
-msgstr ""
-
-#: ../data/ui/preferences_general.blp:36
-msgid "Automatically open links from QR-codes"
-msgstr ""
-
-#: ../data/ui/preferences_languages.blp:6
-msgid "_Languages"
-msgstr ""
-
-#: ../data/ui/preferences_languages.blp:32
-msgid "Installed languages"
-msgstr ""
-
-#: ../data/ui/share_row.blp:14
-msgid "Share via Pocket"
-msgstr ""
-
-#: ../data/ui/share_row.blp:22
-msgid "Pocket"
-msgstr ""
-
-#: ../data/ui/welcome_page.blp:9 ../data/ui/welcome_page.blp:46
-msgid "Extract text from anywhere"
-msgstr ""
-
-#: ../data/ui/welcome_page.blp:18
-msgid "Language"
-msgstr ""
-
-#: ../data/ui/welcome_page.blp:19
-msgid "Select language to extract"
-msgstr ""
-
-#: ../data/ui/welcome_page.blp:26
-msgid "Take a screenshot"
-msgstr ""
-
-#: ../data/ui/welcome_page.blp:40
-msgid "Open menu"
-msgstr ""
-
-#: ../data/ui/welcome_page.blp:67
-msgid "_Take a Screenshot"
-msgstr ""
-
-#: ../data/ui/welcome_page.blp:87
-msgid "_Open Image"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.desktop.in:3
-msgid "Frog"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.desktop.in:4
-msgid "Text extraction tool"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.desktop.in:5
-msgid "Extract text from any image, video or web page"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.desktop.in:12
-msgid "OCR;Text;Extraction;"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.desktop.in:18
-msgid "Extract Text to the Clipboard"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:7
-msgid "Extract text from images"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:9
-msgid ""
-"Extract text from images, websites, videos, and QR codes by taking a picture "
-"of the source."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:24
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:42
-msgid "In this update, we've made a number of improvements to our app."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:26
-msgid ""
-"Share extracted text: This means you can now share your findings with the "
-"wider community."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:27
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:29
-msgid ""
-"Add Text-to-speech to be able to listen to the extracted text without any "
-"additional apps (internet connection required)."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:31
-msgid ""
-"Add the ability to insert images from the clipboard by using the "
-"<code>Ctrl+V</code> shortcut."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:33
-msgid ""
-"In addition, we have upgraded the language selection dropdown to popover "
-"with a quick search of a language."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:35
-msgid "Last but not least, Frog has become more accessibility-friendly."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:37
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:51
-msgid "We hope you enjoy our work!"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:44
-msgid ""
-"We have redesigned the settings dialog to make it more user-friendly and "
-"understandable."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:45
-msgid "Now you can easily find the language you want by searching."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:46
-msgid ""
-"In addition, we have added the ability to select a second language for "
-"extracting text from images."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:47
-msgid "The Frog can automatically follow links extracted from QR codes."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:48
-msgid ""
-"We also updated the localization and improved the overall performance of the "
-"app."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:49
-msgid "Fixed some bugs and bugs."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:56
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:65
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:73
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:82
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:91
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:113
-msgid "What's new:"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:58
-msgid "Open image button now available."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:59
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:67
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:76
-msgid "Translations updated."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:75
-msgid "When no text is found, Frog returns to the main window."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:84
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:93
-msgid "Updated UI"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:85
-msgid "Translated to a bunch of new languages"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:94
-msgid "Drag-n-drop support. For images only"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:95
-msgid "Dark mode support"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:96
-msgid "Localized interface"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:102
-msgid ""
-"Frog now is available on the Flathub and use modern Portal implementation. "
-"We also updated the UI accordingly to the GNOME HIG and fixed some bugs "
-"we've found :)"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:108
-msgid ""
-"Now you're free to run Frog with `-e` option to extract text and instantly "
-"copy it to the clipboard."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:115
-msgid "English model included with Frog itself"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:116
-msgid "QR code detection. If one in the selected area - it will be decoded."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:117
-msgid "New command line shortcut to run with \"Extract to clipboard\" feature."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:118
-msgid "Granite.HyperTextView to support QR encoded links"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:124
-msgid "Fix language packs download."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:129
-msgid "Dark mode+"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:131
-msgid "Dark mode support."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:132
-msgid "Application will hide the main window for the cleaner shots. #11"
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:138
-msgid ""
-"Quickly extract any text from anywhere you need it: webpages, videos, "
-"photos, etc."
-msgstr ""
-
-#: ../data/com.github.tenderowl.frog.appdata.xml.in:143
-msgid "Tender Owl"
+#: ../frog/window.py:293
+msgid "Text copied"
 msgstr ""


### PR DESCRIPTION
GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.

Also update the POT file.