### PR TITLE
Fix image extraction with `Take a Screenshot`

### DIFF
--- a/frog/services/screenshot_service.py
+++ b/frog/services/screenshot_service.py
@@ -28,7 +28,7 @@
 import os
 from gettext import gettext as _
 
-from gi.repository import GObject, Gio, Xdp
+from gi.repository import GObject, Gio, GLib, Xdp
 from loguru import logger
 
 from frog.config import tessdata_config
@@ -101,6 +101,7 @@ class ScreenshotService(GObject.GObject):
         filename = self.portal.take_screenshot_finish(res)
         # Remove file:// from the path
         filename = filename[7:]
+        filename = GLib.Uri.unescape_string(filename)
         self.decode_image(lang, filename, copy, True)
 
     def decode_image(self,
@@ -142,8 +143,11 @@ class ScreenshotService(GObject.GObject):
 
         finally:
             if remove_source:
-                logger.debug(f"Removing {file}")
-                os.unlink(file)
+                try:
+                    logger.debug(f"Removing {file}")
+                    os.unlink(file)
+                except Exception as e:
+                        logger.debug(f"Error deleting {file}: {e}")
 
         if extracted:
             logger.debug("Extracted successfully")


### PR DESCRIPTION
This problem was caused by two separate issues:
1) The file names passed to `Image.Open` were escaped (e.g. " " -> "%20") 
2) Frog tries to delete the file after text extraction but might not have the permissions to do so under a sandbox

Closes #192, #182