### PR TITLE
Port to AdwSpinner

### DIFF
--- a/data/ui/welcome_page.blp
+++ b/data/ui/welcome_page.blp
@@ -32,8 +32,8 @@ template $WelcomePage : Adw.NavigationPage {
         // }
 
         [start]
-        Spinner spinner {
-          spinning: false;
+        Adw.Spinner spinner {
+          visible: false;
         }
 
         [end]

--- a/flatpak/com.github.tenderowl.frog.json
+++ b/flatpak/com.github.tenderowl.frog.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.tenderowl.frog",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "47",
     "sdk" : "org.gnome.Sdk",
     "command" : "frog",
     "finish-args" : [

--- a/frog/widgets/welcome_page.py
+++ b/frog/widgets/welcome_page.py
@@ -40,7 +40,7 @@ from frog.widgets.language_popover import LanguagePopover
 class WelcomePage(Adw.NavigationPage):
     __gtype_name__ = "WelcomePage"
 
-    spinner: Gtk.Spinner = Gtk.Template.Child()
+    spinner: Adw.Spinner = Gtk.Template.Child()
     welcome: Adw.StatusPage = Gtk.Template.Child()
     lang_combo: Gtk.MenuButton = Gtk.Template.Child()
     language_popover: LanguagePopover = Gtk.Template.Child()

--- a/frog/window.py
+++ b/frog/window.py
@@ -129,7 +129,6 @@ class FrogWindow(Adw.ApplicationWindow):
     def get_screenshot(self, copy: bool = False) -> None:
         self.extracted_page.listen_cancel()
         lang = self.get_language()
-        # self.welcome_page.spinner.start()
         self.hide()
         self.backend.capture(lang, copy)
 
@@ -178,11 +177,11 @@ class FrogWindow(Adw.ApplicationWindow):
 
         finally:
             self.present()
-            self.welcome_page.spinner.stop()
+            self.welcome_page.spinner.set_visible(False)
 
     def on_shot_error(self, sender, message: str) -> None:
         self.present()
-        self.welcome_page.spinner.stop()
+        self.welcome_page.spinner.set_visible(False)
         if message:
             self.show_toast(message)
             # self.display_error(self, message)
@@ -207,7 +206,7 @@ class FrogWindow(Adw.ApplicationWindow):
         try:
             item = dialog.open_finish(result)
             lang = self.get_language()
-            self.welcome_page.spinner.start()
+            self.welcome_page.spinner.set_visible(True)
             GObjectWorker.call(self.backend.decode_image, (lang, item.get_path()))
         except GLib.Error as e:
             if not e.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED):
@@ -219,7 +218,7 @@ class FrogWindow(Adw.ApplicationWindow):
         pngbytes = BytesIO(texture.save_to_png_bytes().get_data())
         try:
             lang = self.get_language()
-            self.welcome_page.spinner.start()
+            self.welcome_page.spinner.set_visible(True)
             GObjectWorker.call(self.backend.decode_image, (lang, pngbytes))
         except GLib.Error as e:
             if not e.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED):
@@ -261,7 +260,7 @@ class FrogWindow(Adw.ApplicationWindow):
             return self.show_toast(_("Only images can be processed that way."))
 
         lang = self.get_language()
-        self.welcome_page.spinner.start()
+        self.welcome_page.spinner.set_visible(True)
         GObjectWorker.call(self.backend.decode_image, (lang, item.get_path()))
 
     def on_configure_event(self, window, event):


### PR DESCRIPTION
Use the new libadwaita Spinners from GNOME 47.

The Flathub package needs the GNOME 47 runtime to support the accent color preference. This might be a nice small release to accompany that.