### PR TITLE
chore: remove invalid `–psm 0` option from tessdata_config

### DIFF
--- a/frog/config.py
+++ b/frog/config.py
@@ -41,4 +41,4 @@ if not os.path.exists(os.path.join(os.environ['XDG_DATA_HOME'], 'tessdata')):
 tessdata_url = "https://github.com/tesseract-ocr/tessdata/raw/main/"
 tessdata_best_url = "https://github.com/tesseract-ocr/tessdata_best/raw/main/"
 tessdata_dir = os.path.join(os.environ['XDG_DATA_HOME'], 'tessdata')
-tessdata_config = f'--tessdata-dir {tessdata_dir} –psm 0 --oem 1'
+tessdata_config = f'--tessdata-dir {tessdata_dir} --oem 1'


### PR DESCRIPTION
The `–psm 0` option was ignored by Tesseract because it used an en-dash instead of a hyphen, and only a single dash instead of the required double dash.

Using the correct `--psm 0` is also not appropriate, as it triggers "Orientation and script detection (OSD) only", which does not return any text and causes frog to fail.

As a result, the behavior remains unchanged and continues to default to "Fully automatic page segmentation, but no OSD".
