### PR TITLE
Run the frog backend server with an cli option.

### DIFF
--- a/bin/frog.in
+++ b/bin/frog.in
@@ -36,10 +36,11 @@ import locale
 
 VERSION = '@VERSION@'
 pkgdatadir = '@pkgdatadir@'
+pythondir = '@pythondir@'
 localedir = '@localedir@'
 project_name = '@projectname@'
 
-sys.path.insert(1, pkgdatadir)
+sys.path.insert(1, pythondir)
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 # L10n

--- a/frog/main.py
+++ b/frog/main.py
@@ -72,6 +72,15 @@ class FrogApplication(Adw.Application):
             None
         )
 
+        self.add_main_option(
+            'server',
+            ord('s'),
+            GLib.OptionFlags.NONE,
+            GLib.OptionArg.NONE,
+            _("Run in server mode without GUI."),
+            None
+        )
+
         # Initialize tesseract data files storage.
         language_manager.init_tessdata()
 
@@ -123,6 +132,11 @@ class FrogApplication(Adw.Application):
     def do_command_line(self, command_line):
         options = command_line.get_options_dict()
         options = options.end().unpack()
+
+        if "server" in options:
+            logger.info("Server mode activated. Backend is running.")
+            self.hold()
+            return 0
 
         if "extract_to_clipboard" in options:
             self.backend.capture(self.settings.get_string("active-language"), True)


### PR DESCRIPTION
I've added -s option to frog cli so that frog -e can work well without the gui. 

This also let me execute the server as a service on startup and use keybindings from my hyprland to execute frog -e (without the need to run the app).

![image](https://github.com/user-attachments/assets/d85aefd0-bc0a-4475-b462-084f1ff72200)
